### PR TITLE
Update install-eSim.sh

### DIFF
--- a/Ubuntu/install-eSim.sh
+++ b/Ubuntu/install-eSim.sh
@@ -160,8 +160,12 @@ function installDependency
     echo "Installing Matplotlib......................"
     sudo apt-get install -y python3-matplotlib
 
-    echo "Installing Distutils......................."
-    sudo apt-get install -y python3-distutils
+    # using setuptools in place of distutils.
+    echo "Installing Setuptools......................."
+    sudo apt-get install -y python3-setuptools
+
+    #echo "Installing Distutils......................."
+    #sudo apt-get install -y python3-distutils
 
     # Install NgVeri Depedencies
     echo "Installing Pip3............................"


### PR DESCRIPTION
commenting out the Distutils package and using setuptools in place of it because :- 

- Dependency Management: Easily declare and manage dependencies of project.
- Plugins and Extensions: Support for plugins and extensions to enhance functionality.
- Automated Metadata: Automatically populates package metadata for easier discovery and distribution.
- Better Integration: Integrates well with version control and continuous integration tools.
- Enhanced Features: Provides additional features like creating "eggs" and handling complex packaging scenarios.


